### PR TITLE
Remove default skip marks that are never used in Unicode decomposition

### DIFF
--- a/ttfdiet.py
+++ b/ttfdiet.py
@@ -80,7 +80,7 @@ DEFAULT_OUTPATH_ADDITION          = u".diet"
 
 REPORT_MISSING_MARKS              = 1
 CORRECT_MARK_CLASS                = 1
-SKIP_MARKS                        = u"031B,0321,0322,0334,0335,0336,0337,0338" # you may not want to decompose precomposed ones that involve overstruck/overlay marks, horns or hooks
+SKIP_MARKS                        = u"031B,0338" # you may not want to decompose precomposed ones that involve horn or overstruck long solidus
 SKIP_MARKS_FINAL                  = None
 
 ADD_DUMMY_DSIG                    = 0


### PR DESCRIPTION
According to http://www.unicode.org/Public/7.0.0/ucd/NamesList.txt 0321, 0322, 0334, 0335, 0336, 0337 are not used in any Unicode decomposition.
In the default skip marks list, only 031B, 0338 are used in character decomposition.